### PR TITLE
Add Auth to D.O. Image Pulls

### DIFF
--- a/activities/builder/builder.go
+++ b/activities/builder/builder.go
@@ -26,6 +26,8 @@ import (
 	"github.com/skip-mev/ironbird/types"
 	"github.com/tonistiigi/fsutil"
 	fstypes "github.com/tonistiigi/fsutil/types"
+
+	"github.com/skip-mev/ironbird/util"
 )
 
 type Activity struct {
@@ -62,22 +64,12 @@ var (
 )
 
 func (a *Activity) getAuthenticationToken(ctx context.Context) (string, string, error) {
-	ecrClient := ecrpublic.NewFromConfig(*a.AwsConfig, func(options *ecrpublic.Options) {
-		// ecrpublic only works in us-east-1
-		options.Region = "us-east-1"
-	})
-
-	token, err := ecrClient.GetAuthorizationToken(ctx, &ecrpublic.GetAuthorizationTokenInput{})
-
+	token, err := util.FetchDockerRepoToken(ctx, *a.AwsConfig)
 	if err != nil {
 		return "", "", err
 	}
 
-	if token.AuthorizationData.AuthorizationToken == nil {
-		return "", "", fmt.Errorf("no authorization token found")
-	}
-
-	decodedToken, err := base64.StdEncoding.DecodeString(*token.AuthorizationData.AuthorizationToken)
+	decodedToken, err := base64.StdEncoding.DecodeString(token)
 
 	if err != nil {
 		return "", "", fmt.Errorf("failed to decode token: %w", err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -120,6 +120,7 @@ func main() {
 		Chains:            cfg.Chains,
 		GrafanaConfig:     cfg.Grafana,
 		GRPCClient:        grpcClient,
+		AwsConfig:         &awsConfig,
 	}
 
 	loadTestActivity := loadtest.Activity{

--- a/util/aws.go
+++ b/util/aws.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
+)
+
+func FetchDockerRepoToken(ctx context.Context, awsCfg aws.Config) (string, error) {
+	ecrClient := ecrpublic.NewFromConfig(awsCfg, func(options *ecrpublic.Options) {
+		// ecrpublic only works in us-east-1
+		options.Region = "us-east-1"
+	})
+
+	token, err := ecrClient.GetAuthorizationToken(ctx, &ecrpublic.GetAuthorizationTokenInput{})
+	if err != nil {
+		return "", err
+	} else if token.AuthorizationData == nil {
+		return "", fmt.Errorf("no authorization token found")
+	}
+
+	return *token.AuthorizationData.AuthorizationToken, nil
+}

--- a/workflows/testnet/testnet.go
+++ b/workflows/testnet/testnet.go
@@ -155,7 +155,7 @@ func launchTestnet(ctx workflow.Context, req messages.TestnetWorkflowRequest, ru
 
 	var testnetResp messages.LaunchTestnetResponse
 	activityOptions := workflow.ActivityOptions{
-		HeartbeatTimeout:    time.Minute * 4,
+		HeartbeatTimeout:    time.Minute * 10,
 		StartToCloseTimeout: time.Hour * 24 * 365,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,

--- a/workflows/testnet/testnet_test.go
+++ b/workflows/testnet/testnet_test.go
@@ -302,6 +302,12 @@ func (s *TestnetWorkflowTestSuite) setupMockActivitiesDigitalOcean() {
 		panic(err)
 	}
 
+	awsConfig, err := config.LoadDefaultConfig(context.TODO())
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
 	cfg, err := types.ParseWorkerConfig("../../conf/worker.yaml")
 	if err != nil {
 		s.T().Fatal(err)
@@ -310,6 +316,7 @@ func (s *TestnetWorkflowTestSuite) setupMockActivitiesDigitalOcean() {
 		DOToken:           doToken,
 		TailscaleSettings: tailscaleSettings,
 		Chains:            cfg.Chains,
+		AwsConfig:         &awsConfig,
 	}
 	loadBalancerActivity := &loadbalancer.Activity{
 		RootDomain:        "ib-local.dev.skip.build",
@@ -329,12 +336,6 @@ func (s *TestnetWorkflowTestSuite) setupMockActivitiesDigitalOcean() {
 		TailscaleSettings: tailscaleSettings,
 	}
 	s.env.RegisterActivity(loadTestActivity.RunLoadTest)
-
-	awsConfig, err := config.LoadDefaultConfig(context.TODO())
-
-	if err != nil {
-		log.Fatalln(err)
-	}
 
 	builderConfig := types.BuilderConfig{
 		BuildKitAddress: "tcp://localhost:1234",


### PR DESCRIPTION
Closes: https://linear.app/cosmoslabs/issue/STACK-1362/ironbird-docker-retryable-errors

Providing an auth token in the image pull requests will increase the allowed rate at which we can pull from 1 per second to 10 per second. This resolves the failures due to rate limiting when setting up nodes for now.

Relies on changes in https://github.com/skip-mev/petri/pull/227