### PR TITLE
fix: align account[0] passphrase with catalyst

### DIFF
--- a/petri/cosmos/chain/chain.go
+++ b/petri/cosmos/chain/chain.go
@@ -939,7 +939,11 @@ func buildAccounts(walletCfg petritypes.WalletConfig, baseMnemonic string, start
 	accounts := make([]Account, 0, numAdditionalAccs)
 	for i := range numAdditionalAccs {
 		keyName := fmt.Sprintf("additionalaccount%d", i)
-		w, err := wallet.NewWallet(keyName, baseMnemonic, fmt.Sprintf("%d", i), walletCfg)
+		passphrase := fmt.Sprintf("%d", i)
+		if i == 0 {
+			passphrase = ""
+		}
+		w, err := wallet.NewWallet(keyName, baseMnemonic, passphrase, walletCfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create wallet %d: %w", i+1, err)
 		}


### PR DESCRIPTION
for more info, https://github.com/skip-mev/catalyst/blob/c9d0409495649db8587ae20afd35a0f2e5b526e7/chains/ethereum/wallet/wallet.go#L81